### PR TITLE
RamRoot: Create server/routes/leads.cjs with:
- POST /api/leads  body: {email,name?,note?}  -> append to server/files/leads.json (create file/dir if missing). Validate basic email; return {ok:true,id,createdAt}.
- GET  /api/self/leads -> return last 50 leads (newest first).
Also wire it in server/server.cjs: 
  const leadsRouter = require('./routes/leads.cjs');
  app.use('/api', leadsRouter);

### DIFF
--- a/server/routes/leads.cjs
+++ b/server/routes/leads.cjs
@@ -1,0 +1,35 @@
+const express = require('express');
+const fs = require('fs');
+const router = express.Router();
+const leadsFilePath = './server/files/leads.json';
+
+// POST endpoint to create a new lead
+router.post('/', (req, res) => {
+    const newLead = {
+        id: Date.now(),
+        createdAt: new Date().toISOString(),
+        ...req.body
+    };
+
+    fs.readFile(leadsFilePath, 'utf8', (err, data) => {
+        if (err) return res.status(500).json({ ok: false, error: 'Failed to read leads file.' });
+        const leads = JSON.parse(data || '[]');
+        leads.push(newLead);
+        fs.writeFile(leadsFilePath, JSON.stringify(leads), (err) => {
+            if (err) return res.status(500).json({ ok: false, error: 'Failed to save lead.' });
+            res.json({ ok: true, id: newLead.id, createdAt: newLead.createdAt });
+        });
+    });
+});
+
+// GET endpoint to retrieve the last 50 leads
+router.get('/', (req, res) => {
+    fs.readFile(leadsFilePath, 'utf8', (err, data) => {
+        if (err) return res.status(500).json({ ok: false, error: 'Failed to read leads file.' });
+        const leads = JSON.parse(data || '[]');
+        const lastLeads = leads.slice(-50).reverse();
+        res.json(lastLeads);
+    });
+});
+
+module.exports = router;


### PR DESCRIPTION
Auto-generated by Builder.

Plan: {
  "plan": [
    "Parse error"
  ],
  "raw": "```json\n{\n  \"plan\": [\n    \"Create server/routes/leads.cjs with POST and GET endpoints.\",\n    \"Implement logic to append leads to server/files/leads.json and return the required responses.\"\n  ],\n  \"files_to_touch\": [\n    {\n      \"path\": \"server/routes/leads.cjs\",\n      \"purpose\": \"To implement the new API endpoints for managing leads.\"\n    },\n    {\n      \"path\": \"server/server.cjs\",\n      \"purpose\": \"To wire the new leads router into the main server application.\"\n    },\n    {\n      \"path\": \"server/files/leads.json\",\n      \"purpose\": \"To store the leads data persistently.\"\n    }\n  ],\n  \"acceptance_criteria\": [\n    \"POST /api/leads returns {ok:true,id,createdAt} for valid requests.\",\n    \"GET /api/self/leads returns the last 50 leads in descending order.\"\n  ]\n}\n```"
}