### PR TITLE
wire: mount leads router at /api

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -42,6 +42,7 @@ const leadsRouter = require('./routes/leads.cjs');
 
 app.use('/triage', (triageRouter.default || triageRouter));
 app.use('/api/relevance', relevanceRouter);
+app.use('/api', leadsRouter);
 app.use('/api/coach', coachRouter);
 app.use('/api/builder', builderRouter);
 app.use('/api/self', prsRouter);


### PR DESCRIPTION
Edited `server/server.cjs`

• find: `app.use('/api/relevance', relevanceRouter);`
• replace: `app.use('/api/relevance', relevanceRouter);
app.use('/api', leadsRouter);`