### PR TITLE
leads: add CSV export /api/self/leads.csv

### DIFF
--- a/server/routes/leads.cjs
+++ b/server/routes/leads.cjs
@@ -9,4 +9,13 @@ function readLeads(){ try{ return JSON.parse(fs.readFileSync(LEADS_PATH,"utf8"))
 function writeLeads(a){ fs.mkdirSync(path.dirname(LEADS_PATH), { recursive:true }); fs.writeFileSync(LEADS_PATH, JSON.stringify(a,null,2)); }
 router.post("/leads",(req,res)=>{ try{ const { email, name, note } = req.body || {}; if(!email) return res.status(400).json({ ok:false, error:"email_required" }); const id = Date.now().toString(36); const createdAt = new Date().toISOString(); const rec = { id, email, name, note, createdAt }; const arr = readLeads(); arr.push(rec); writeLeads(arr); res.json({ ok:true, id, createdAt }); } catch(e){ res.status(500).json({ ok:false, error:String(e?.message||e)}); } });
 router.get("/self/leads",(req,res)=>{ const arr = readLeads().sort((a,b)=> String(b.createdAt).localeCompare(String(a.createdAt))).slice(0,50); res.json(arr); });
+router.get("/self/leads.csv", (_req,res) => {
+  const arr = readLeads()
+    .sort((a,b)=>String(b.createdAt).localeCompare(String(a.createdAt))))
+    .slice(0,500);
+  const q = s => '"' + String(s ?? '').replace(/"/g,'""') + '"';
+  const lines = ["id,email,name,note,createdAt",
+    ...arr.map(x => [x.id,x.email,x.name,x.note,x.createdAt].map(q).join(","))];
+  res.type("text/csv").send(lines.join("\n"));
+});
 module.exports = router;


### PR DESCRIPTION
Edited `server/routes/leads.cjs`

• find: `module.exports = router;`
• replace: `router.get("/self/leads.csv", (_req,res) => {
  const arr = readLeads()
    .sort((a,b)=>String(b.createdAt).localeCompare(String(a.createdAt))))
    .slice(0,500);
  const q = s => '"' + String(s ?? '').replace(/"/g,'""') + '"';
  const lines = ["id,email,name,note,createdAt",
    ...arr.map(x => [x.id,x.email,x.name,x.note,x.createdAt].map(q).join(","))];
  res.type("text/csv").send(lines.join("\n"));
});
module.exports = router;`