### PR TITLE
leads: add CSV export /api/self/leads.csv

### DIFF
--- a/server/routes/leads.cjs
+++ b/server/routes/leads.cjs
@@ -27,4 +27,13 @@ router.get('/self/leads.csv', (req,res) => {
     ...arr.map(x => [x.id,x.email,x.name,x.note,x.createdAt].map(q).join(','))];
   res.type('text/csv').send(lines.join('\n'));
 });
+router.get('/self/leads.csv', (_req, res) => {
+  const arr = readLeads()
+    .sort((a,b)=> String(b.createdAt).localeCompare(String(a.createdAt)))
+    .slice(0,50);
+  const q = s => '"' + String(s ?? '').replace(/"/g,'""') + '"';
+  const lines = ['id,email,name,note,createdAt',
+    ...arr.map(x => [x.id,x.email,x.name,x.note,x.createdAt].map(q).join(','))];
+  res.type('text/csv').send(lines.join('\n'));
+});
 module.exports = router;


### PR DESCRIPTION
Edited `server/routes/leads.cjs`

• find: `module.exports = router;`
• replace: `router.get('/self/leads.csv', (_req, res) => {
  const arr = readLeads()
    .sort((a,b)=> String(b.createdAt).localeCompare(String(a.createdAt)))
    .slice(0,50);
  const q = s => '"' + String(s ?? '').replace(/"/g,'""') + '"';
  const lines = ['id,email,name,note,createdAt',
    ...arr.map(x => [x.id,x.email,x.name,x.note,x.createdAt].map(q).join(','))];
  res.type('text/csv').send(lines.join('\n'));
});
module.exports = router;`